### PR TITLE
Remove achievements button from management controls

### DIFF
--- a/glados_launcher/gui.py
+++ b/glados_launcher/gui.py
@@ -229,7 +229,6 @@ class ApertureEnrichmentCenterGUI:
             ("REMOVE", self.remove_selected_game),
             ("REMOVE ALL", self.remove_all_games),
             ("RATE", self.rate_selected_game),
-            ("ACHIEVEMENTS", self.show_achievements),
             ("MINI GAMES", self.show_mini_games),
             ("ANALYSIS", self.show_analysis),
             ("PREFS", self.show_preferences),


### PR DESCRIPTION
## Summary
- remove the Achievements button from the management controls in the main GUI header so it no longer appears in the interface

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68def6532a2883268b177a078d9b787c