### PR TITLE
Add platform-safe winreg compatibility shim

### DIFF
--- a/glados_launcher/dependencies.py
+++ b/glados_launcher/dependencies.py
@@ -1,0 +1,26 @@
+"""Compatibility helpers for optional platform-specific modules."""
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+try:  # pragma: no cover - exercised only on Windows
+    import winreg  # type: ignore
+except ImportError:  # pragma: no cover - Windows only module
+    class _WinRegStub(SimpleNamespace):
+        """Minimal stub mirroring the winreg API used in the project."""
+
+        def __init__(self) -> None:
+            super().__init__(
+                HKEY_LOCAL_MACHINE=None,
+            )
+
+        def __getattr__(self, name: str):  # noqa: D401 - simple passthrough
+            raise AttributeError(
+                "winreg is not available on this platform (sys.platform="
+                f"{sys.platform!r})."
+            )
+
+    winreg = _WinRegStub()  # type: ignore
+
+__all__ = ["winreg"]


### PR DESCRIPTION
## Summary
- add a compatibility helper so importing winreg works gracefully on non-Windows systems
- ensure the launcher can still import its scanner module without missing dependency errors

## Testing
- python -m compileall glados_launcher/dependencies.py

------
https://chatgpt.com/codex/tasks/task_e_68df07e493c48326ba36fea788033854