### PR TITLE
Improve Apply Update button visibility

### DIFF
--- a/glados_launcher/theme.py
+++ b/glados_launcher/theme.py
@@ -32,6 +32,7 @@ class ApertureTheme:
     BUTTON_NORMAL = "#223447"
     BUTTON_HOVER = "#2f4c66"
     BUTTON_ACTIVE = "#3a5f7d"
+    BUTTON_DISABLED = "#1b2835"
 
     BORDER_LIGHT = "#3c5064"
     BORDER_DARK = "#0b1118"


### PR DESCRIPTION
## Summary
- add a dedicated Apply Update button next to the system controls
- disable or enable the button based on update support and check results to avoid confusing states
- reset the button state after running update installation attempts
- ensure the Apply Update button remains visible even when disabled by styling the state to match the Aperture theme

## Testing
- python -m compileall glados_launcher

------
https://chatgpt.com/codex/tasks/task_e_68e1c139bbe88326bbbd77b0f3d88900