### PR TITLE
Remove duplicate Mini-Games Lab button

### DIFF
--- a/glados_launcher/gui.py
+++ b/glados_launcher/gui.py
@@ -349,13 +349,6 @@ class ApertureEnrichmentCenterGUI:
             style="Aperture.TButton",
             command=self.open_store_page,
         ).pack(side="left", padx=4)
-        ttk.Button(
-            quick_buttons,
-            text="Mini-Games Lab",
-            style="Aperture.TButton",
-            command=self.focus_mini_games_lab,
-        ).pack(side="left", padx=4)
-
         ttk.Separator(button_frame, orient="vertical", style="Aperture.TSeparator").pack(side="left", fill="y", padx=18)
 
         mgmt_frame = ttk.Frame(button_frame, style="Header.TFrame")


### PR DESCRIPTION
## Summary
- remove the redundant "Mini-Games Lab" quick-action button from the header controls
- leave the notebook tab as the single access point for the mini-games section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1cbe736e4832685dcebbea9baf187