### PR TITLE
Embed Train Tetris mini-game inside Mini-Games Lab tab

### DIFF
--- a/glados_launcher/gui.py
+++ b/glados_launcher/gui.py
@@ -559,6 +559,21 @@ class ApertureEnrichmentCenterGUI:
             width=22,
         ).pack(side="left", padx=(10, 0))
 
+        display_container = ttk.Frame(mini_games_tab, style="Panel.TFrame")
+        display_container.pack(fill="both", expand=True, padx=10, pady=(0, 10))
+
+        self.mini_game_display = ttk.Frame(display_container, style="Panel.TFrame")
+        self.mini_game_display.pack(fill="both", expand=True)
+
+        self.mini_game_placeholder = ttk.Label(
+            self.mini_game_display,
+            text="No simulation active. Launch the training module to begin.",
+            style="PanelBody.TLabel",
+            anchor="center",
+            justify="center",
+        )
+        self.mini_game_placeholder.pack(expand=True, fill="both", padx=20, pady=20)
+
         system_tab = ttk.Frame(notebook, style="Panel.TFrame")
         notebook.add(system_tab, text="System Options")
         self.system_tab = system_tab
@@ -1458,19 +1473,35 @@ class ApertureEnrichmentCenterGUI:
             pass
 
     def show_tetris(self) -> None:
-        if hasattr(self, "tetris") and isinstance(self.tetris, TrainTetrisGame) and self.tetris.is_open:
-            self.tetris.focus()
+        self.focus_mini_games_lab()
+
+        existing = getattr(self, "tetris", None)
+        if isinstance(existing, TrainTetrisGame) and existing.is_open:
+            existing.focus()
             return
+
+        if getattr(self, "mini_game_placeholder", None) is not None:
+            try:
+                self.mini_game_placeholder.pack_forget()
+            except Exception:
+                pass
 
         self.tetris = TrainTetrisGame(
             self.root,
             on_close=self._handle_tetris_closed,
             achievement_manager=self.achievement_manager,
+            parent=getattr(self, "mini_game_display", None),
         )
+        self.tetris.focus()
 
     def _handle_tetris_closed(self) -> None:
         self.tetris = None
         self.update_mini_game_panel()
+        if getattr(self, "mini_game_placeholder", None) is not None:
+            try:
+                self.mini_game_placeholder.pack(expand=True, fill="both", padx=20, pady=20)
+            except Exception:
+                pass
 
     def check_for_updates(self) -> None:
         if self.update_check_in_progress:

--- a/glados_launcher/gui.py
+++ b/glados_launcher/gui.py
@@ -564,6 +564,8 @@ class ApertureEnrichmentCenterGUI:
 
         self.mini_game_display = ttk.Frame(display_container, style="Panel.TFrame")
         self.mini_game_display.pack(fill="both", expand=True)
+        self.mini_game_display.pack_propagate(False)
+        self.mini_game_display.configure(width=720, height=720)
 
         self.mini_game_placeholder = ttk.Label(
             self.mini_game_display,


### PR DESCRIPTION
## Summary
- add a dedicated mini-game display frame with a placeholder inside the Mini-Games Lab tab
- embed TrainTetrisGame in the launcher when the existing window is not reused and keep focus/cleanup logic consistent
- move keyboard bindings to the game canvas so controls continue to work in the embedded host

## Testing
- python -m compileall glados_launcher

------
https://chatgpt.com/codex/tasks/task_e_68e1cfe2a4008326b07d29c11b2445ab